### PR TITLE
Allow laquo and raquo in HardCodedString linter

### DIFF
--- a/lib/erb_lint/linters/hard_coded_string.rb
+++ b/lib/erb_lint/linters/hard_coded_string.rb
@@ -41,6 +41,8 @@ module ERBLint
         "&emsp;",
         "&thinsp;",
         "&times;",
+        "&laquo;",
+        "&raquo;",
       ])
 
       class ConfigSchema < LinterConfig


### PR DESCRIPTION
Adds `&laquo;` and `&raquo;` to the `NO_TRANSLATION_NEEDED` set in the `HardCodedString` linter