### PR TITLE
Switch from deprecated Cop.all API to Rubocop v1 Registry.all

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ PATH
       better_html (>= 2.0.1)
       parser (>= 2.7.1.4)
       rainbow
-      rubocop
+      rubocop (>= 1)
       smart_properties
 
 GEM
@@ -123,4 +123,4 @@ DEPENDENCIES
   rubocop-shopify
 
 BUNDLED WITH
-   2.3.16
+   2.4.20

--- a/erb_lint.gemspec
+++ b/erb_lint.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_dependency("better_html", ">= 2.0.1")
   s.add_dependency("parser", ">= 2.7.1.4")
   s.add_dependency("rainbow")
-  s.add_dependency("rubocop")
+  s.add_dependency("rubocop", ">= 1")
   s.add_dependency("smart_properties")
 
   s.add_development_dependency("rspec")

--- a/lib/erb_lint/linters/rubocop.rb
+++ b/lib/erb_lint/linters/rubocop.rb
@@ -146,10 +146,10 @@ module ERBLint
 
       def cop_classes
         if @only_cops.present?
-          selected_cops = ::RuboCop::Cop::Cop.all.select { |cop| cop.match?(@only_cops) }
+          selected_cops = ::RuboCop::Cop::Registry.all.select { |cop| cop.match?(@only_cops) }
           ::RuboCop::Cop::Registry.new(selected_cops)
         else
-          ::RuboCop::Cop::Registry.new(::RuboCop::Cop::Cop.all)
+          ::RuboCop::Cop::Registry.new(::RuboCop::Cop::Registry.all)
         end
       end
 

--- a/lib/erb_lint/linters/rubocop_text.rb
+++ b/lib/erb_lint/linters/rubocop_text.rb
@@ -29,7 +29,7 @@ module ERBLint
       end
 
       def cop_classes
-        selected_cops = ::RuboCop::Cop::Cop.all.select { |cop| cop.match?(@only_cops) }
+        selected_cops = ::RuboCop::Cop::Registry.all.select { |cop| cop.match?(@only_cops) }
 
         ::RuboCop::Cop::Registry.new(selected_cops)
       end


### PR DESCRIPTION
API change is noted in the V1 upgrade notes here, so there's also a `>= 1` requirement on the `rubocop` gem: https://docs.rubocop.org/rubocop/v1_upgrade_notes.html

Without this, `erb-lint` winds up emitting a ton of deprecation warnings when used with `rubocop` `>= 1.65.0`, which introduces warning messages for deprecated APIs: https://github.com/rubocop/rubocop/pull/13032