### PR TITLE
Replace deprecated Cop.all

### DIFF
--- a/erb_lint.gemspec
+++ b/erb_lint.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_dependency("better_html", ">= 2.0.1")
   s.add_dependency("parser", ">= 2.7.1.4")
   s.add_dependency("rainbow")
-  s.add_dependency("rubocop")
+  s.add_dependency("rubocop", "~> 1.0")
   s.add_dependency("smart_properties")
 
   s.add_development_dependency("rspec")

--- a/lib/erb_lint/linters/rubocop.rb
+++ b/lib/erb_lint/linters/rubocop.rb
@@ -146,10 +146,10 @@ module ERBLint
 
       def cop_classes
         if @only_cops.present?
-          selected_cops = ::RuboCop::Cop::Cop.all.select { |cop| cop.match?(@only_cops) }
+          selected_cops = ::RuboCop::Cop::Registry.all.select { |cop| cop.match?(@only_cops) }
           ::RuboCop::Cop::Registry.new(selected_cops)
         else
-          ::RuboCop::Cop::Registry.new(::RuboCop::Cop::Cop.all)
+          ::RuboCop::Cop::Registry.new(::RuboCop::Cop::Registry.all)
         end
       end
 

--- a/lib/erb_lint/linters/rubocop_text.rb
+++ b/lib/erb_lint/linters/rubocop_text.rb
@@ -29,7 +29,7 @@ module ERBLint
       end
 
       def cop_classes
-        selected_cops = ::RuboCop::Cop::Cop.all.select { |cop| cop.match?(@only_cops) }
+        selected_cops = ::RuboCop::Cop::Registry.all.select { |cop| cop.match?(@only_cops) }
 
         ::RuboCop::Cop::Registry.new(selected_cops)
       end


### PR DESCRIPTION
Use Registry.all instead.  Cop.all was deprecated when rubocop 1.0 was released

Fixes #361 