### PR TITLE
Drop support for rubocop < 1.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,14 +6,14 @@ jobs:
       fail-fast: false
       matrix:
         ruby: [2.7, 3.0, 3.1, 3.2, 3.3, head]
-        gemfile: [rubocop-next, rubocop-old]
+        gemfile: [rubocop-next]
     runs-on: ubuntu-latest
     env: # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps
       BUNDLE_GEMFILE: gemfiles/Gemfile.${{ matrix.gemfile }}
     steps:
-    - uses: actions/checkout@v3
-    - uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby }}
-        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-    - run: bundle exec rspec
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+      - run: bundle exec rspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ PATH
       better_html (>= 2.0.1)
       parser (>= 2.7.1.4)
       rainbow
-      rubocop
+      rubocop (~> 1.0)
       smart_properties
 
 GEM

--- a/erb_lint.gemspec
+++ b/erb_lint.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_dependency("better_html", ">= 2.0.1")
   s.add_dependency("parser", ">= 2.7.1.4")
   s.add_dependency("rainbow")
-  s.add_dependency("rubocop")
+  s.add_dependency("rubocop", "~> 1.0")
   s.add_dependency("smart_properties")
 
   s.add_development_dependency("rspec")

--- a/gemfiles/Gemfile.rubocop-old
+++ b/gemfiles/Gemfile.rubocop-old
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-eval_gemfile "../Gemfile"
-
-gem "rubocop", "< 0.87"


### PR DESCRIPTION
Version 1.0 was released 2020-10-21 (nearly four years ago). Maintaining compatability means that erb_lint emits a lot of deprecation warnings or we have to add conditionals.