### PR TITLE
Add none reporter and option to hide file header for better in editor support

### DIFF
--- a/lib/erb_lint/cli.rb
+++ b/lib/erb_lint/cli.rb
@@ -102,7 +102,7 @@ module ERBLint
 
       if stdin? && autocorrect?
         # When running from stdin, we only lint a single file
-        puts "================ #{lint_files.first} ==================\n"
+        puts "================ #{lint_files.first} ==================\n" unless @options[:no_file_header]
         puts file_content
       end
 
@@ -401,6 +401,10 @@ module ERBLint
           "Pipe source from STDIN. Takes the path to be used to check which rules to apply.",
         ) do |file|
           @options[:stdin] = [file]
+        end
+
+        opts.on("--no-file-header", "Disable file header while reading from stding for autocorrect.") do
+          @options[:no_file_header] = true
         end
 
         opts.on_tail("-h", "--help", "Show this message") do

--- a/lib/erb_lint/reporters/none_reporter.rb
+++ b/lib/erb_lint/reporters/none_reporter.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module ERBLint
+  module Reporters
+    class NoneReporter < Reporter
+      def preview
+      end
+
+      def show
+      end
+    end
+  end
+end

--- a/spec/erb_lint/cli_spec.rb
+++ b/spec/erb_lint/cli_spec.rb
@@ -93,7 +93,7 @@ describe ERBLint::CLI do
       it "shows format instructions" do
         expect { subject }.to(
           output(Regexp.new("Report offenses in the given format: " \
-            "\\(compact, gitlab, json, junit, multiline\\) " \
+            "\\(compact, gitlab, json, junit, multiline, none\\) " \
             "\\(default: multiline\\)")).to_stdout,
         )
       end
@@ -532,6 +532,7 @@ describe ERBLint::CLI do
                   - json
                   - junit
                   - multiline
+                  - none
               EOF
             end
 
@@ -654,6 +655,8 @@ describe ERBLint::CLI do
               ["--enable-linter", "final_newline,linter_with_errors", "--stdin", linted_file, "--autocorrect"]
             end
 
+            let(:full_linted_file_path) { "#{Dir.pwd}/#{linted_file}" }
+
             it "tells the user it is autocorrecting" do
               expect { subject }.to(output(/Linting and autocorrecting/).to_stdout)
             end
@@ -662,8 +665,48 @@ describe ERBLint::CLI do
               expect { subject }.to(output(/2 linters \(1 autocorrectable\)/).to_stdout)
             end
 
+            it "outputs file header" do
+              expect { subject }.to(output(/#{linted_file} ==================\n/).to_stdout)
+            end
+
             it "outputs the corrected ERB" do
               expect { subject }.to(output(/#{file_content}\n/).to_stdout)
+            end
+
+            context "when file header was turned of" do
+              let(:args) do
+                [
+                  "--enable-linter",
+                  "final_newline,linter_with_errors",
+                  "--stdin",
+                  linted_file,
+                  "--autocorrect",
+                  "--no-file-header",
+                ]
+              end
+
+              it "does not output file header" do
+                expect { subject }.not_to(output(/#{linted_file} ==================\n/).to_stdout)
+              end
+
+              context "when format is none" do
+                let(:args) do
+                  [
+                    "--enable-linter",
+                    "final_newline,linter_with_errors",
+                    "--stdin",
+                    linted_file,
+                    "--autocorrect",
+                    "--no-file-header",
+                    "--format",
+                    "none",
+                  ]
+                end
+
+                it "outputs only the corrected ERB" do
+                  expect { subject }.to(output("#{file_content}\n").to_stdout)
+                end
+              end
             end
           end
 


### PR DESCRIPTION
Hey 👋 

The goal of this PR is to make it easier to use this great tool within editors, for example using it with [conform](https://github.com/stevearc/conform.nvim). It does that by adding a new reporter: `none`, which will prevent reporting any linter output to stdout, and by adding flag `--no-file-header` which will prevent outputting this line:
```
================ /path/to/file.html.erb ==================
```

Naming is hard, so more than happy to adjust naming.

Example:
![image](https://github.com/user-attachments/assets/f115513f-9797-4835-bcd1-5fa7f0bd1f31)


There is another PR with similar changes: #357, the main differences are:

- `none` reporter just does not output anything instead of moving the lining logs into stderr, as I was afraid it might still be read by some editors.
- I didn't want to change behavior of all cli outputs by setting `--format` - personally wouldn't expect that from the CLI, so instead I decided to add new flag that disabled the file header from above.

---

If someone found this out looking for solution for `conform` - even if this is not merged, you still can use `erb_lint` with conform, just not through stdin, example configuration:
```lua
    formatters = {
      erb_lint = {
        stdin = false,
        tmpfile_format = ".conform.$RANDOM.$FILENAME",
        command = "bundle",
        args = { "exec", "erblint", "--autocorrect", "$FILENAME" },
      },
    },
```