### PR TITLE
Don't use possibly deprecated RuboCop api

### DIFF
--- a/lib/erb_lint/linters/rubocop.rb
+++ b/lib/erb_lint/linters/rubocop.rb
@@ -154,7 +154,7 @@ module ERBLint
       end
 
       def build_team
-        ::RuboCop::Cop::Team.new(
+        ::RuboCop::Cop::Team.mobilize(
           cop_classes,
           @rubocop_config,
           extra_details: true,


### PR DESCRIPTION
See https://github.com/rubocop/rubocop/blob/8fc2afce8e9379ffa3aeb87f23593ca5b1f8c02c/lib/rubocop/cop/team.rb#L15-L16

There is no deprecation at the moment, but it was added as a temporary measure: https://github.com/rubocop/rubocop/pull/8088. Also see https://github.com/rubocop/rubocop/pull/13244

RuboCop must be >= 1.0, so this is fine