### PR TITLE
Rename `CACHE_DIRECTORY` to `.erb_lint_cache`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -736,7 +736,7 @@ File names pruned from the cache will be logged
 No errors were found in ERB files
 ```
 
-Cached lint results are stored in the `.erb-lint-cache` directory by default, though a custom directory can be provided
+Cached lint results are stored in the `.erb_lint_cache` directory by default, though a custom directory can be provided
 via the `--cache-dir` option. Cache filenames are computed with a hash of information about the file and `erb_lint` settings.
 These files store instance attributes of the `CachedOffense` object, which only contain the `Offense` attributes
 necessary to restore the results of running `erb_lint` for output. The cache also automatically prunes outdated files each time it's run.

--- a/lib/erb_lint/cache.rb
+++ b/lib/erb_lint/cache.rb
@@ -2,7 +2,7 @@
 
 module ERBLint
   class Cache
-    CACHE_DIRECTORY = ".erb-lint-cache"
+    CACHE_DIRECTORY = ".erb_lint_cache"
 
     def initialize(config, cache_dir = nil)
       @config = config


### PR DESCRIPTION
From `.erb-lint-cache`.

This is to align with the general renaming and standardization from `erb-lint` and `erblint` to `erb_lint`.

Fixes #379.