### PR TITLE
Release erb_lint v0.7.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    erb_lint (0.6.0)
+    erb_lint (0.7.0)
       activesupport
       better_html (>= 2.0.1)
       parser (>= 2.7.1.4)

--- a/lib/erb_lint/version.rb
+++ b/lib/erb_lint/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ERBLint
-  VERSION = "0.6.0"
+  VERSION = "0.7.0"
 end


### PR DESCRIPTION
There are useful unreleased fixes and features, so cutting a release makes sense to me.

Main changes are:

- Consistently use the `erb_lint` name, instead of `erb-lint` or `erblint`. The old names are still supported, but will be removed in a future release. 
https://github.com/Shopify/erb_lint/pull/360

- Rename the cache directory to match the new name. Your first build will rebuild it from scratch.
https://github.com/Shopify/erb_lint/pull/380

- Don't use rexml for the JUnit formatter
https://github.com/Shopify/erb_lint/pull/374

- Allow laquo and raquo in HardCodedString linter
https://github.com/Shopify/erb_lint/pull/355

- Don't use possibly deprecated RuboCop api
https://github.com/Shopify/erb_lint/pull/375