### PR TITLE
Add support for using `erb_lint` in inline config comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ You can disable a rule by placing a disable comment in the following format:
 
 Comment on offending lines
 ```.erb
-<hr /> <%# erblint:disable SelfClosingTag %>
+<hr /> <%# erb_lint:disable SelfClosingTag %>
 ```
 
 To raise an error when there is a useless disable comment, enable `NoUnusedDisable`.

--- a/lib/erb_lint/utils/inline_configs.rb
+++ b/lib/erb_lint/utils/inline_configs.rb
@@ -4,11 +4,11 @@ module ERBLint
   module Utils
     class InlineConfigs
       def self.rule_disable_comment_for_lines?(rule, lines)
-        lines.match?(/# erblint:disable (?<rules>.*#{rule}).*/)
+        lines.match?(/# erb_?lint:disable (?<rules>.*#{rule}).*/)
       end
 
       def self.disabled_rules(line)
-        line.match(/# erblint:disable (?<rules>.*) %>/)&.named_captures&.fetch("rules")
+        line.match(/# erb_?lint:disable (?<rules>.*) %>/)&.named_captures&.fetch("rules")
       end
     end
   end

--- a/spec/lib/erb_lint/utils/inline_configs_spec.rb
+++ b/spec/lib/erb_lint/utils/inline_configs_spec.rb
@@ -11,6 +11,11 @@ describe ERBLint::Utils::InlineConfigs do
       expect(utils.rule_disable_comment_for_lines?("AnchorRule", offending_lines)).to(be(true))
     end
 
+    it "supports both erb_lint and erblint naming" do
+      offending_lines = '<a href="#"></a><%# erb_lint:disable AnchorRule %>'
+      expect(utils.rule_disable_comment_for_lines?("AnchorRule", offending_lines)).to(be(true))
+    end
+
     it "true lines when lines contain a erblint:disable comment for rule in Ruby comment" do
       offending_lines = '<%
 			button = {


### PR DESCRIPTION
On updating to `0.7.0` and the changes introduced by #360, I was a little surprised to find that the magic inline comment for `erb_lint` was still only `erblint`

This PR adds support for `erb_lint` , eg `erb_lint:disable (...)`

I believe this furthers the consolidation on `erb_lint` as the canonical naming of the tool.

Let me know if there is anything else this needs. 

Thanks for `erb_lint`!