### PR TITLE
Extend SpaceInHtmlTag to trim values

### DIFF
--- a/lib/erb_lint/linters/space_in_html_tag.rb
+++ b/lib/erb_lint/linters/space_in_html_tag.rb
@@ -96,6 +96,15 @@ module ERBLint
           name, equal, value = *attribute
           no_space(processed_source, name.loc.end_pos...equal.loc.begin_pos) if name && equal
           no_space(processed_source, equal.loc.end_pos...value.loc.begin_pos) if equal && value
+          if value && quoted_value?(value)
+            open_quote, str, close_quote = *value
+            leading_spaces = str.chars.take_while { |char| char == " " }.count
+            trailing_spaces = str.chars.reverse.take_while { |char| char == " " }.count
+            first_non_space_pos = open_quote.loc.end_pos + leading_spaces
+            last_non_space_pos = close_quote.loc.begin_pos - trailing_spaces
+            no_space(processed_source, (open_quote.loc.end_pos)...first_non_space_pos)
+            no_space(processed_source, last_non_space_pos...close_quote.loc.begin_pos)
+          end
 
           next if index >= attributes.children.size - 1
 
@@ -106,6 +115,10 @@ module ERBLint
             attribute.loc.end_pos...next_attribute.loc.begin_pos,
           )
         end
+      end
+
+      def quoted_value?(value)
+        value.children.length == 3
       end
     end
   end

--- a/spec/erb_lint/linters/space_in_html_tag_spec.rb
+++ b/spec/erb_lint/linters/space_in_html_tag_spec.rb
@@ -52,6 +52,16 @@ describe ERBLint::Linters::SpaceInHtmlTag do
         it { expect(subject).to(eq([])) }
       end
 
+      context "self-closing tag with valueless attribute" do
+        let(:file) { "<input autofocus />" }
+        it { expect(subject).to(eq([])) }
+      end
+
+      context "self-closing tag with no quotes around attribute value" do
+        let(:file) { "<input class=foo />" }
+        it { expect(subject).to(eq([])) }
+      end
+
       context "between attributes" do
         let(:file) { '<input class="foo" name="bar" />' }
         it { expect(subject).to(eq([])) }
@@ -144,6 +154,24 @@ describe ERBLint::Linters::SpaceInHtmlTag do
         it do
           expect(subject).to(eq([
             build_offense(9..10, "Extra space detected where there should be no space."),
+          ]))
+        end
+      end
+
+      context "at start of value" do
+        let(:file) { "<div foo='  bar'>" }
+        it do
+          expect(subject).to(eq([
+            build_offense(10..11, "Extra space detected where there should be no space."),
+          ]))
+        end
+      end
+
+      context "at end of value" do
+        let(:file) { "<div foo='bar  '>" }
+        it do
+          expect(subject).to(eq([
+            build_offense(13..14, "Extra space detected where there should be no space."),
           ]))
         end
       end
@@ -429,6 +457,16 @@ describe ERBLint::Linters::SpaceInHtmlTag do
 
       context "between attribute equal and value" do
         let(:file) { "<div foo=  'bar'>" }
+        it { expect(subject).to(eq("<div foo='bar'>")) }
+      end
+
+      context "at start of value" do
+        let(:file) { "<div foo='  bar'>" }
+        it { expect(subject).to(eq("<div foo='bar'>")) }
+      end
+
+      context "at end of value" do
+        let(:file) { "<div foo='bar  '>" }
         it { expect(subject).to(eq("<div foo='bar'>")) }
       end
     end


### PR DESCRIPTION
In our code base, we merged in some code that looked like this:

```
<input type=" button " />
```

Which ultimately did not work. The browser did not understand this. We wondered if ERB Lint could have caught it. And now here we are.

What do we think?