### PR TITLE
Output everything to stderr, except the autocorrect file content

### DIFF
--- a/lib/erb_lint/cache.rb
+++ b/lib/erb_lint/cache.rb
@@ -9,7 +9,7 @@ module ERBLint
       @cache_dir = cache_dir || CACHE_DIRECTORY
       @hits = []
       @new_results = []
-      puts "Cache mode is on"
+      $stderr.puts "Cache mode is on"
     end
 
     def get(filename, file_content)
@@ -44,7 +44,7 @@ module ERBLint
 
     def prune_cache
       if hits.empty?
-        puts "Cache being created for the first time, skipping prune"
+        $stderr.puts "Cache being created for the first time, skipping prune"
         return
       end
 
@@ -63,7 +63,7 @@ module ERBLint
     def clear
       return unless cache_dir_exists?
 
-      puts "Clearing cache by deleting cache directory"
+      $stderr.puts "Clearing cache by deleting cache directory"
       FileUtils.rm_r(@cache_dir)
     end
 

--- a/lib/erb_lint/cli.rb
+++ b/lib/erb_lint/cli.rb
@@ -108,13 +108,13 @@ module ERBLint
 
       @stats.found == 0 && @stats.exceptions == 0
     rescue OptionParser::InvalidOption, OptionParser::InvalidArgument, ExitWithFailure => e
-      warn(Rainbow(e.message).red)
+      $stderr.puts(Rainbow(e.message).red)
       false
     rescue ExitWithSuccess => e
       puts e.message
       true
     rescue => e
-      warn(Rainbow("#{e.class}: #{e.message}\n#{e.backtrace.join("\n")}").red)
+      $stderr.puts(Rainbow("#{e.class}: #{e.message}\n#{e.backtrace.join("\n")}").red)
       false
     end
 
@@ -218,11 +218,11 @@ module ERBLint
         deprecation_message = "The config file has been renamed to `#{DEFAULT_CONFIG_FILENAME}` and " \
           "`#{DEPRECATED_CONFIG_FILENAME}` is deprecated. " \
           "Please rename your config file to `#{DEFAULT_CONFIG_FILENAME}`."
-        warn(Rainbow(deprecation_message).yellow)
+        $stderr.puts(Rainbow(deprecation_message).yellow)
         config = RunnerConfig.new(file_loader.yaml(DEPRECATED_CONFIG_FILENAME), file_loader)
         @config = RunnerConfig.default_for(config)
       else
-        warn(Rainbow("#{config_filename} not found: using default config").yellow)
+        $stderr.puts(Rainbow("#{config_filename} not found: using default config").yellow)
         @config = RunnerConfig.default
       end
     rescue Psych::SyntaxError => e

--- a/lib/erb_lint/cli.rb
+++ b/lib/erb_lint/cli.rb
@@ -87,12 +87,12 @@ module ERBLint
           file_content = run_on_file(runner, filename)
         rescue => e
           @stats.exceptions += 1
-          puts "Exception occurred when processing: #{relative_filename(filename)}"
-          puts "If this file cannot be processed by erb_lint, " \
+          $stderr.puts "Exception occurred when processing: #{relative_filename(filename)}"
+          $stderr.puts "If this file cannot be processed by erb_lint, " \
             "you can exclude it in your configuration file."
-          puts e.message
-          puts Rainbow(e.backtrace.join("\n")).red
-          puts
+          $stderr.puts e.message
+          $stderr.puts Rainbow(e.backtrace.join("\n")).red
+          $stderr.puts
         end
       end
 
@@ -102,7 +102,7 @@ module ERBLint
 
       if stdin? && autocorrect?
         # When running from stdin, we only lint a single file
-        puts "================ #{lint_files.first} ==================\n"
+        $stderr.puts "================ #{lint_files.first} =================="
         puts file_content
       end
 
@@ -111,7 +111,7 @@ module ERBLint
       $stderr.puts(Rainbow(e.message).red)
       false
     rescue ExitWithSuccess => e
-      puts e.message
+      $stderr.puts e.message
       true
     rescue => e
       $stderr.puts(Rainbow("#{e.class}: #{e.message}\n#{e.backtrace.join("\n")}").red)

--- a/lib/erb_lint/linter_registry.rb
+++ b/lib/erb_lint/linter_registry.rb
@@ -34,7 +34,7 @@ module ERBLint
         if deprecated_ruby_files.any?
           deprecation_message = "The '#{DEPRECATED_CUSTOM_LINTERS_DIR}' directory for custom linters is deprecated. " \
             "Please rename it to '#{CUSTOM_LINTERS_DIR}'"
-          warn(Rainbow(deprecation_message).yellow)
+          $stderr.puts(Rainbow(deprecation_message).yellow)
           ruby_files.concat(deprecated_ruby_files)
         end
 

--- a/lib/erb_lint/reporters/compact_reporter.rb
+++ b/lib/erb_lint/reporters/compact_reporter.rb
@@ -4,13 +4,13 @@ module ERBLint
   module Reporters
     class CompactReporter < Reporter
       def preview
-        puts "#{linting} #{stats.files} files with #{linters}..."
+        $stderr.puts "#{linting} #{stats.files} files with #{linters}..."
       end
 
       def show
         processed_files.each do |filename, offenses|
           offenses.each do |offense|
-            puts format_offense(filename, offense)
+            $stderr.puts format_offense(filename, offense)
           end
         end
 
@@ -52,7 +52,7 @@ module ERBLint
             $stderr.puts(Rainbow("#{stats.found} error(s) were found in ERB files").red)
           end
         else
-          puts Rainbow("No errors were found in ERB files").green
+          $stderr.puts Rainbow("No errors were found in ERB files").green
         end
       end
 
@@ -66,7 +66,7 @@ module ERBLint
 
           $stderr.puts(message)
         else
-          puts Rainbow("#{stats.corrected} error(s) corrected in ERB files").green
+          $stderr.puts Rainbow("#{stats.corrected} error(s) corrected in ERB files").green
         end
       end
     end

--- a/lib/erb_lint/reporters/compact_reporter.rb
+++ b/lib/erb_lint/reporters/compact_reporter.rb
@@ -45,11 +45,11 @@ module ERBLint
           report_corrected_offenses
         elsif stats.ignored > 0 || stats.found > 0
           if stats.ignored > 0
-            warn(Rainbow("#{stats.ignored} error(s) were ignored in ERB files").yellow)
+            $stderr.puts(Rainbow("#{stats.ignored} error(s) were ignored in ERB files").yellow)
           end
 
           if stats.found > 0
-            warn(Rainbow("#{stats.found} error(s) were found in ERB files").red)
+            $stderr.puts(Rainbow("#{stats.found} error(s) were found in ERB files").red)
           end
         else
           puts Rainbow("No errors were found in ERB files").green
@@ -64,7 +64,7 @@ module ERBLint
             "#{stats.corrected} error(s) corrected and #{corrected_found_diff} error(s) remaining in ERB files",
           ).red
 
-          warn(message)
+          $stderr.puts(message)
         else
           puts Rainbow("#{stats.corrected} error(s) corrected in ERB files").green
         end

--- a/lib/erb_lint/reporters/multiline_reporter.rb
+++ b/lib/erb_lint/reporters/multiline_reporter.rb
@@ -21,7 +21,7 @@ module ERBLint
       end
 
       def footer
-        puts
+        $stderr.puts
       end
     end
   end

--- a/spec/erb_lint/cache_spec.rb
+++ b/spec/erb_lint/cache_spec.rb
@@ -92,7 +92,7 @@ describe ERBLint::Cache do
     it "skips prune if no cache hits" do
       allow(cache).to(receive(:hits).and_return([]))
 
-      expect { cache.prune_cache }.to(output(/Cache being created for the first time, skipping prune/).to_stdout)
+      expect { cache.prune_cache }.to(output(/Cache being created for the first time, skipping prune/).to_stderr)
     end
 
     it "does not prune actual cache hits" do

--- a/spec/erb_lint/cli_spec.rb
+++ b/spec/erb_lint/cli_spec.rb
@@ -79,21 +79,21 @@ describe ERBLint::CLI do
 
     context "with --version" do
       let(:args) { ["--version"] }
-      it { expect { subject }.to(output("#{ERBLint::VERSION}\n").to_stdout) }
+      it { expect { subject }.to(output("#{ERBLint::VERSION}\n").to_stderr) }
     end
 
     context "with --help" do
       let(:args) { ["--help"] }
 
       it "shows usage" do
-        expect { subject }.to(output(/erblint \[options\] \[file1, file2, ...\]/).to_stdout)
+        expect { subject }.to(output(/erblint \[options\] \[file1, file2, ...\]/).to_stderr)
       end
 
       it "shows format instructions" do
         expect { subject }.to(
           output(Regexp.new("Report offenses in the given format: " \
             "\\(compact, gitlab, json, junit, multiline\\) " \
-            "\\(default: multiline\\)")).to_stdout,
+            "\\(default: multiline\\)")).to_stderr,
         )
       end
 
@@ -143,7 +143,7 @@ describe ERBLint::CLI do
       end
 
       it "shows all errors regardless of inline disables " do
-        expect { subject }.to(output(/ERBLint::Linters::FakeLinter error/).to_stdout)
+        expect { subject }.to(output(/ERBLint::Linters::FakeLinter error/).to_stderr)
       end
     end
 
@@ -163,7 +163,8 @@ describe ERBLint::CLI do
         it {
           expect do
             subject
-          end.to(output(<<~EOF).to_stdout)
+          end.to(output(<<~EOF).to_stderr)
+            #{Rainbow(".erb_lint.yml not found: using default config").yellow}
             Cache mode is on
             Clearing cache by deleting cache directory
             cache directory cleared
@@ -217,7 +218,7 @@ describe ERBLint::CLI do
       end
 
       it "uses the specified directory" do
-        expect { subject }.to(output(/cache directory cleared/).to_stdout)
+        expect { subject }.to(output(/cache directory cleared/).to_stderr)
       end
     end
 
@@ -247,12 +248,12 @@ describe ERBLint::CLI do
         end
 
         it "shows how many files and linters are used" do
-          expect { subject }.to(output(/Linting 1 files with 2 linters/).to_stdout)
+          expect { subject }.to(output(/Linting 1 files with 2 linters/).to_stderr)
         end
 
         context "when errors are found" do
           it "shows all error messages and line numbers" do
-            expect { subject }.to(output(Regexp.new(Regexp.escape(<<~EOF))).to_stdout)
+            expect { subject }.to(output(Regexp.new(Regexp.escape(<<~EOF))).to_stderr)
 
               fake message from a fake linter
               In file: /app/views/template.html.erb:1
@@ -276,7 +277,7 @@ describe ERBLint::CLI do
           let(:args) { ["--enable-linter", "linter_with_info_errors", linted_file] }
 
           it "shows all error messages and line numbers" do
-            expect { subject }.to(output(Regexp.new(Regexp.escape(<<~EOF))).to_stdout)
+            expect { subject }.to(output(Regexp.new(Regexp.escape(<<~EOF))).to_stderr)
 
               fake info message from a fake linter
               In file: /app/views/template.html.erb:1
@@ -297,7 +298,7 @@ describe ERBLint::CLI do
           let(:args) { ["--enable-linter", "linter_without_errors", linted_file] }
 
           it "shows that no errors were found to stdout" do
-            expect { subject }.to(output(/No errors were found in ERB files/).to_stdout)
+            expect { subject }.to(output(/No errors were found in ERB files/).to_stderr)
           end
 
           it "is successful" do
@@ -327,7 +328,7 @@ describe ERBLint::CLI do
           it "lints the file and adds it to the cache" do
             expect(Dir[ERBLint::Cache::CACHE_DIRECTORY].length).to(be(0))
 
-            expect { subject }.to(output(/Cache mode is on/).to_stdout)
+            expect { subject }.to(output(/Cache mode is on/).to_stderr)
             expect(subject).to(be(true))
 
             expect(Dir[ERBLint::Cache::CACHE_DIRECTORY].length).to(be(1))
@@ -350,7 +351,7 @@ describe ERBLint::CLI do
         context "with the default glob" do
           it "shows how many files and linters are used" do
             allow(cli).to(receive(:glob).and_return(cli.class::DEFAULT_LINT_ALL_GLOB))
-            expect { subject }.to(output(/Linting 1 files with 2 linters/).to_stdout)
+            expect { subject }.to(output(/Linting 1 files with 2 linters/).to_stderr)
           end
         end
 
@@ -377,7 +378,7 @@ describe ERBLint::CLI do
 
         context "with the default glob" do
           it "shows all error messages and line numbers" do
-            expect { subject }.to(output(Regexp.new(Regexp.escape(<<~EOF))).to_stdout)
+            expect { subject }.to(output(Regexp.new(Regexp.escape(<<~EOF))).to_stderr)
 
               fake info message from a fake linter
               In file: /app/views/template.html.erb:1
@@ -400,7 +401,7 @@ describe ERBLint::CLI do
 
         context "with the default glob" do
           it "shows all error messages and line numbers" do
-            expect { subject }.to(output(Regexp.new(Regexp.escape(<<~EOF))).to_stdout)
+            expect { subject }.to(output(Regexp.new(Regexp.escape(<<~EOF))).to_stderr)
 
               fake info message from a fake linter
               In file: /app/views/template.html.erb:1
@@ -464,12 +465,12 @@ describe ERBLint::CLI do
           end
 
           it "shows how many files and linters are used" do
-            expect { subject }.to(output(/Linting 1 files with 2 linters/).to_stdout)
+            expect { subject }.to(output(/Linting 1 files with 2 linters/).to_stderr)
           end
 
           context "when errors are found" do
             it "shows all error messages and line numbers" do
-              expect { subject }.to(output(Regexp.new(Regexp.escape(<<~EOF))).to_stdout)
+              expect { subject }.to(output(Regexp.new(Regexp.escape(<<~EOF))).to_stderr)
 
                 fake message from a fake linter
                 In file: /app/views/template.html.erb:1
@@ -501,7 +502,7 @@ describe ERBLint::CLI do
             end
 
             it "shows all error messages and line numbers" do
-              expect { subject }.to(output(Regexp.new(Regexp.escape(<<~EOF))).to_stdout)
+              expect { subject }.to(output(Regexp.new(Regexp.escape(<<~EOF))).to_stderr)
                 /app/views/template.html.erb:1:1: fake message from a fake linter
                 /app/views/template.html.erb:1:19: Missing a trailing newline at the end of the file.
               EOF
@@ -543,7 +544,7 @@ describe ERBLint::CLI do
             let(:args) { ["--enable-linter", "linter_without_errors", linted_dir] }
 
             it "shows that no errors were found to stdout" do
-              expect { subject }.to(output(/No errors were found in ERB files/).to_stdout)
+              expect { subject }.to(output(/No errors were found in ERB files/).to_stderr)
             end
 
             it "is successful" do
@@ -556,7 +557,7 @@ describe ERBLint::CLI do
               it "lints the file and adds it to the cache" do
                 expect(Dir[ERBLint::Cache::CACHE_DIRECTORY].length).to(be(0))
 
-                expect { subject }.to(output(/Cache mode is on/).to_stdout)
+                expect { subject }.to(output(/Cache mode is on/).to_stderr)
                 expect(subject).to(be(true))
 
                 expect(Dir[ERBLint::Cache::CACHE_DIRECTORY].length).to(be(1))
@@ -623,12 +624,12 @@ describe ERBLint::CLI do
         end
 
         it "shows how many files and linters are used" do
-          expect { subject }.to(output(/Linting 1 files with 2 linters/).to_stdout)
+          expect { subject }.to(output(/Linting 1 files with 2 linters/).to_stderr)
         end
 
         context "when errors are found" do
           it "shows all error messages and line numbers" do
-            expect { subject }.to(output(Regexp.new(Regexp.escape(<<~EOF))).to_stdout)
+            expect { subject }.to(output(Regexp.new(Regexp.escape(<<~EOF))).to_stderr)
 
               fake message from a fake linter
               In file: /app/views/template.html.erb:1
@@ -654,11 +655,11 @@ describe ERBLint::CLI do
             end
 
             it "tells the user it is autocorrecting" do
-              expect { subject }.to(output(/Linting and autocorrecting/).to_stdout)
+              expect { subject }.to(output(/Linting and autocorrecting/).to_stderr)
             end
 
             it "shows how many total and autocorrectable linters are used" do
-              expect { subject }.to(output(/2 linters \(1 autocorrectable\)/).to_stdout)
+              expect { subject }.to(output(/2 linters \(1 autocorrectable\)/).to_stderr)
             end
 
             it "outputs the corrected ERB" do
@@ -682,7 +683,7 @@ describe ERBLint::CLI do
           let(:args) { ["--enable-linter", "linter_without_errors", "--stdin", linted_file] }
 
           it "shows that no errors were found to stdout" do
-            expect { subject }.to(output(/No errors were found in ERB files/).to_stdout)
+            expect { subject }.to(output(/No errors were found in ERB files/).to_stderr)
           end
 
           it "is successful" do
@@ -721,7 +722,7 @@ describe ERBLint::CLI do
             end
 
             it "exits with success status" do
-              expect { subject }.to(output(/no files found\.\.\./).to_stdout)
+              expect { subject }.to(output(/no files found\.\.\./).to_stderr)
               expect(subject).to(be(true))
             end
           end

--- a/spec/erb_lint/linter_registry_spec.rb
+++ b/spec/erb_lint/linter_registry_spec.rb
@@ -36,9 +36,8 @@ describe ERBLint::LinterRegistry do
       stub_const("ERBLint::LinterRegistry::DEPRECATED_CUSTOM_LINTERS_DIR", custom_directory)
 
       expected_warning = Rainbow("The '#{custom_directory}' directory for custom linters is deprecated. " \
-        "Please rename it to '.erb_linters'").yellow
-      expect(described_class).to(receive(:warn).with(expected_warning).once)
-      described_class.load_custom_linters
+        "Please rename it to '.erb_linters'").yellow + "\n"
+      expect { described_class.load_custom_linters }.to(output(expected_warning).to_stderr)
     end
   end
 end

--- a/spec/erb_lint/reporters/compact_reporter_spec.rb
+++ b/spec/erb_lint/reporters/compact_reporter_spec.rb
@@ -74,7 +74,7 @@ describe ERBLint::Reporters::CompactReporter do
     end
 
     it "displays formatted offenses output" do
-      expect { subject }.to(output(<<~MESSAGE).to_stdout)
+      expect { subject }.to(output(a_string_starting_with(<<~MESSAGE)).to_stderr)
         app/views/users/show.html.erb:61:10: Extra space detected where there should be no space.
         app/views/users/show.html.erb:125:1: Remove multiple trailing newline at the end of the file.
         app/views/users/show.html.erb:145:4: Trailing comma expected.
@@ -88,7 +88,7 @@ describe ERBLint::Reporters::CompactReporter do
       let(:show_linter_names) { true }
 
       it "displays formatted offenses output with linter names" do
-        expect { subject }.to(output(<<~MESSAGE).to_stdout)
+        expect { subject }.to(output(a_string_starting_with(<<~MESSAGE)).to_stderr)
           app/views/users/show.html.erb:61:10: [SpaceInHtmlTag] Extra space detected where there should be no space.
           app/views/users/show.html.erb:125:1: [FinalNewline] Remove multiple trailing newline at the end of the file.
           app/views/users/show.html.erb:145:4: [TrailingComma] Trailing comma expected.
@@ -100,7 +100,7 @@ describe ERBLint::Reporters::CompactReporter do
     end
 
     it "outputs offenses summary to stderr" do
-      expect { subject }.to(output(<<~MESSAGE).to_stderr)
+      expect { subject }.to(output(a_string_ending_with(<<~MESSAGE)).to_stderr)
         #{Rainbow("2 error(s) were ignored in ERB files").yellow}
         #{Rainbow("4 error(s) were found in ERB files").red}
       MESSAGE

--- a/spec/erb_lint/reporters/multiline_reporter_spec.rb
+++ b/spec/erb_lint/reporters/multiline_reporter_spec.rb
@@ -39,7 +39,7 @@ describe ERBLint::Reporters::MultilineReporter do
       let(:show_linter_names) { false }
 
       it "displays formatted offenses output" do
-        expect { subject }.to(output(<<~MESSAGE).to_stdout)
+        expect { subject }.to(output(a_string_starting_with(<<~MESSAGE)).to_stderr)
 
           Extra space detected where there should be no space.
           In file: app/views/subscriptions/_loader.html.erb:1
@@ -56,7 +56,7 @@ describe ERBLint::Reporters::MultilineReporter do
       let(:show_linter_names) { true }
 
       it "displays formatted offenses output" do
-        expect { subject }.to(output(<<~MESSAGE).to_stdout)
+        expect { subject }.to(output(a_string_starting_with(<<~MESSAGE)).to_stderr)
 
           [SpaceInHtmlTag] Extra space detected where there should be no space.
           In file: app/views/subscriptions/_loader.html.erb:1
@@ -73,7 +73,7 @@ describe ERBLint::Reporters::MultilineReporter do
       let(:show_linter_names) { false }
 
       it "displays not autocorrected warning" do
-        expect { subject }.to(output(/(not autocorrected)/).to_stdout)
+        expect { subject }.to(output(/(not autocorrected)/).to_stderr)
       end
     end
   end


### PR DESCRIPTION
Fix #225

This PR modifies all the code that outputs to write to stderr, allowing to use editor integrations by simply taking stdout as the autocorrected result.