### PR TITLE
Add `ignored_words` option to HardCodedString linter

### DIFF
--- a/spec/erb_lint/linters/hard_coded_string_spec.rb
+++ b/spec/erb_lint/linters/hard_coded_string_spec.rb
@@ -89,6 +89,24 @@ describe ERBLint::Linters::HardCodedString do
     it { expect(subject).to(eq([])) }
   end
 
+  context "when file contains hard coded number" do
+    let(:file) { <<~FILE }
+      &copy; 2024
+    FILE
+
+    it { expect(subject).to(eq([])) }
+  end
+
+  context "when file contains hard coded string added to the list of ignored words" do
+    let(:file) { <<~FILE }
+      &copy; My brand 2024
+    FILE
+
+    let(:linter_options) { { ignored_words: ["My brand"] } }
+
+    it { expect(subject).to(eq([])) }
+  end
+
   context "when file contains irrelevant hard coded string" do
     let(:file) { <<~FILE }
       <span class="example">


### PR DESCRIPTION
Adds support for custom translation exceptions via configuration. Users can now specify additional strings that should be exempt from translation requirements, alongside the default `NO_TRANSLATION_NEEDED` list. This is useful for:

- Brand names
- Custom HTML entities
- Project-specific terms
- Any strings that shouldn't trigger translation warnings

Usage example:
```yml
linters:
  HardCodedString:
    ignored_words:
      - MyBrand
      - "&sect;"
 ```