### PR TITLE
Add config option to disable StrictLocals when EnableDefaultLinters is enabled

### DIFF
--- a/lib/erb_lint/runner_config.rb
+++ b/lib/erb_lint/runner_config.rb
@@ -64,6 +64,7 @@ module ERBLint
             TrailingWhitespace: { enabled: default_enabled },
             RequireInputAutocomplete: { enabled: default_enabled },
             CommentSyntax: { enabled: default_enabled },
+            StrictLocals: { enabled: default_enabled },
           },
         )
       end


### PR DESCRIPTION
The StrictLocals linter was added in January this year but no configuration options were added to allow users to disable the linter

Currently, you can disable default linters `EnableDefaultLinters:  false`, and enable StrictLocals but it's not possible to enable default linters and selectively disabled StrictLocals.

### This is possible currently
```yml
EnableDefaultLinters: false
linters:
  StrictLocals: 
    enabled: true
```

### This is **not** possible currently
```yml
EnableDefaultLinters: true
linters:
  StrictLocals: 
    enabled: false
```