### PR TITLE
MINOR/docs: adds a tip to the README.md stating that config example contains linter configs that might not exist on the dev's machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ linters:
         - .rubocop.yml
 ```
 
+> [!TIP]
+> Creating an `.erb_lint.yml` config file is _not_ mandatory; **the tool works out of the box with default settings**.
+> 
+>  Please note that the two config files referenced in the examples above and below _must_ exist, or you will get an error. (Of course, you can ommit the two config file references (i.e. the `better_html_config` key, and the `rubocop_config` section.)
+
 See below for linter-specific configuration options.
 
 ## Usage


### PR DESCRIPTION
Users, like ~me~ a friend of mine, or @AndrewKrasnoff in #354, might simply copy the example configuration from the readme file and then get an error running erb_lint. 

This adds a tip that it is:

a) not needed to provide a config, and 
b) that the example config contains references to linter config files, that might not exist on the user's machine.

Not strictly necessary (if you take your time before pasting), but a good hint and better onboarding experience for users who just copy stuff from readme files like monkeys do. 🙊