### PR TITLE
Rename erblint:disable to erb_lint:disable.

### DIFF
--- a/lib/erb_lint/linters/no_unused_disable.rb
+++ b/lib/erb_lint/linters/no_unused_disable.rb
@@ -37,7 +37,7 @@ module ERBLint
           line_numbers.each do |line_number|
             add_offense(
               processed_source.source_buffer.line_range(line_number),
-              "Unused erblint:disable comment for #{rule}",
+              "Unused erb_lint:disable comment for #{rule}",
             )
           end
         end

--- a/spec/erb_lint/cli_spec.rb
+++ b/spec/erb_lint/cli_spec.rb
@@ -133,7 +133,7 @@ describe ERBLint::CLI do
       end
       let(:linted_file) { "app/views/template.html.erb" }
       let(:args) { ["--disable-inline-configs", "--enable-linter", "fake_linter", linted_file] }
-      let(:file_content) { "<violation></violation> <%# erblint:disable FakeLinter %>" }
+      let(:file_content) { "<violation></violation> <%# erb_lint:disable FakeLinter %>" }
 
       before do
         allow(ERBLint::LinterRegistry).to(receive(:linters)

--- a/spec/erb_lint/linters/no_unused_disable_spec.rb
+++ b/spec/erb_lint/linters/no_unused_disable_spec.rb
@@ -22,16 +22,16 @@ describe ERBLint::Linters::NoUnusedDisable do
   describe "offenses" do
     subject { offenses }
     context "when file has unused disable comment" do
-      let(:file) { "<span></span><%# erblint:disable Fake %>" }
+      let(:file) { "<span></span><%# erb_lint:disable Fake %>" }
       before { linter.run(processed_source, []) }
       it do
         expect(subject.size).to(eq(1))
-        expect(subject.first.message).to(eq("Unused erblint:disable comment for Fake"))
+        expect(subject.first.message).to(eq("Unused erb_lint:disable comment for Fake"))
       end
     end
 
     context "when file has a disable comment and a corresponding offense" do
-      let(:file) { "<span></span><%# erblint:disable Fake %>" }
+      let(:file) { "<span></span><%# erb_lint:disable Fake %>" }
       before do
         offense = ERBLint::Offense.new(
           ERBLint::Linters::Fake.new(file_loader, linter_config),
@@ -49,7 +49,7 @@ describe ERBLint::Linters::NoUnusedDisable do
 
     context "when file has a disable comment in wrong place and a corresponding offense" do
       let(:file) { <<~FILE }
-        <%# erblint:disable Fake %>
+        <%# erb_lint:disable Fake %>
         <span>bad content</span>
       FILE
       before do
@@ -64,12 +64,12 @@ describe ERBLint::Linters::NoUnusedDisable do
 
       it "reports the unused inline comment" do
         expect(subject.size).to(eq(1))
-        expect(subject.first.message).to(eq("Unused erblint:disable comment for Fake"))
+        expect(subject.first.message).to(eq("Unused erb_lint:disable comment for Fake"))
       end
     end
 
     context "when file has disable comment for multiple rules" do
-      let(:file) { "<span></span><%# erblint:disable Fake, Fake2 %>" }
+      let(:file) { "<span></span><%# erb_lint:disable Fake, Fake2 %>" }
       before do
         offense = ERBLint::Offense.new(
           ERBLint::Linters::Fake.new(file_loader, linter_config),
@@ -82,14 +82,14 @@ describe ERBLint::Linters::NoUnusedDisable do
 
       it "reports the unused inline comment" do
         expect(subject.size).to(eq(1))
-        expect(subject.first.message).to(eq("Unused erblint:disable comment for Fake2"))
+        expect(subject.first.message).to(eq("Unused erb_lint:disable comment for Fake2"))
       end
     end
 
     context "when file has multiple disable comments for one offense" do
       let(:file) { <<~ERB }
-        <%# erblint:disable Fake %>
-        <span></span><%# erblint:disable Fake %>
+        <%# erb_lint:disable Fake %>
+        <span></span><%# erb_lint:disable Fake %>
       ERB
       before do
         offense = ERBLint::Offense.new(
@@ -103,7 +103,7 @@ describe ERBLint::Linters::NoUnusedDisable do
 
       it "reports the unused inline comment" do
         expect(subject.size).to(eq(1))
-        expect(subject.first.message).to(eq("Unused erblint:disable comment for Fake"))
+        expect(subject.first.message).to(eq("Unused erb_lint:disable comment for Fake"))
       end
     end
   end

--- a/spec/erb_lint/runner_spec.rb
+++ b/spec/erb_lint/runner_spec.rb
@@ -178,7 +178,7 @@ describe ERBLint::Runner do
       let(:file) { <<~FILE }
         <div>something</div>
         <span>bad content</span>
-        <%# erblint:disable FakeLinter3 %>
+        <%# erb_lint:disable FakeLinter3 %>
       FILE
       let(:processed_source) { ERBLint::ProcessedSource.new(filename, file) }
 
@@ -194,7 +194,7 @@ describe ERBLint::Runner do
       let(:filename) { "somefolder/otherfolder/dummyfile.html.erb" }
       let(:file) { <<~FILE }
         <div>something</div>
-        <span>bad content</span><%# erblint:disable FakeLinter3 %>
+        <span>bad content</span><%# erb_lint:disable FakeLinter3 %>
       FILE
       let(:processed_source) { ERBLint::ProcessedSource.new(filename, file) }
 
@@ -209,7 +209,7 @@ describe ERBLint::Runner do
       let(:filename) { "somefolder/otherfolder/dummyfile.html.erb" }
       let(:file) { <<~FILE }
         <div>something</div>
-        <span>bad content</span> <%# erblint:disable FakeLinter3, FakeLinter4 %>
+        <span>bad content</span> <%# erb_lint:disable FakeLinter3, FakeLinter4 %>
       FILE
       let(:processed_source) { ERBLint::ProcessedSource.new(filename, file) }
 

--- a/spec/lib/erb_lint/utils/inline_configs_spec.rb
+++ b/spec/lib/erb_lint/utils/inline_configs_spec.rb
@@ -6,8 +6,8 @@ describe ERBLint::Utils::InlineConfigs do
   let(:utils) { described_class }
 
   context "rule_disable_comment_for_lines?" do
-    it "true when lines contain a erblint:disable comment for rule in ERB" do
-      offending_lines = '<a href="#"></a><%# erblint:disable AnchorRule %>'
+    it "true when lines contain a erb_lint:disable comment for rule in ERB" do
+      offending_lines = '<a href="#"></a><%# erb_lint:disable AnchorRule %>'
       expect(utils.rule_disable_comment_for_lines?("AnchorRule", offending_lines)).to(be(true))
     end
 
@@ -16,38 +16,38 @@ describe ERBLint::Utils::InlineConfigs do
       expect(utils.rule_disable_comment_for_lines?("AnchorRule", offending_lines)).to(be(true))
     end
 
-    it "true lines when lines contain a erblint:disable comment for rule in Ruby comment" do
+    it "true lines when lines contain a erb_lint:disable comment for rule in Ruby comment" do
       offending_lines = '<%
 			button = {
-					role: "img" # erblint:disable IncorrectRoleRule
+					role: "img" # erb_lint:disable IncorrectRoleRule
 			}
 			%>'
       expect(utils.rule_disable_comment_for_lines?("IncorrectRoleRule", offending_lines)).to(be(true))
     end
 
-    it "true lines when lines contain matching erblint:disable comment for rule in Ruby comment" do
+    it "true lines when lines contain matching erb_lint:disable comment for rule in Ruby comment" do
       offending_lines = '<%
 			button = {
-					role: "img" # erblint:disable IncorrectRoleRule, AnotherRule
+					role: "img" # erb_lint:disable IncorrectRoleRule, AnotherRule
 			}
 			%>'
       expect(utils.rule_disable_comment_for_lines?("AnotherRule", offending_lines)).to(be(true))
     end
 
-    it "false when lines contain erblint:disable comment that does not contain specified rule" do
-      offending_lines = '<a href="#"></a><%# erblint:disable AnchorRule %>'
+    it "false when lines contain erb_lint:disable comment that does not contain specified rule" do
+      offending_lines = '<a href="#"></a><%# erb_lint:disable AnchorRule %>'
       expect(utils.rule_disable_comment_for_lines?("AnotherRule", offending_lines)).to(be(false))
     end
   end
 
   context "disabled_rules" do
     it "returns rule in ERB" do
-      lines = '<a href="#"></a><%# erblint:disable AnchorRule %>'
+      lines = '<a href="#"></a><%# erb_lint:disable AnchorRule %>'
       expect(utils.disabled_rules(lines)).to(eq("AnchorRule"))
     end
 
     it "returns rules in ERB" do
-      lines = '<a href="#"></a><%# erblint:disable Rule1, Rule2, Rule3 %>'
+      lines = '<a href="#"></a><%# erb_lint:disable Rule1, Rule2, Rule3 %>'
       expect(utils.disabled_rules(lines)).to(eq("Rule1, Rule2, Rule3"))
     end
   end


### PR DESCRIPTION
To add consistency and match README instructions as described here:

https://github.com/Shopify/erb_lint?tab=readme-ov-file#disable-rule-at-offense-level